### PR TITLE
Make tests OS independent

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Exactly 15 kilos of data",
   "main": "index.js",
   "scripts": {
-    "test": "./test.sh"
+    "test": "node test.js"
   },
   "keywords": [
     "fifteen",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,10 @@
+var fs = require('fs');
+var fileSize = fs.statSync('./index.js').size;
+
+if (fileSize === 15000) {
+  console.log('index.js is exctly fifteen kilos');
+  process.exit(0);
+} else {
+  console.log('!!index.js is not exactly fifteen kilos!!');
+  process.exit(1);
+}

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,0 @@
-if [ $(stat -f%z index.js)  -eq 15000 ]
-then
-	echo "index.js is exactly fifteen kilos"
-	exit 0
-else
-	echo "!!index.js is not exactly fifteen kilos!!"
-	exit 1
-fi


### PR DESCRIPTION
Use JS/node to test for the file size. This should be relatively
independent of the OS, as this has the same API on Mac, Linux and
(probably) Windows.

I found this necessary, as the `stat` commands does not have the same syntax on Mac and on Linux and probably not even available on Windows. Thus the test kept failing on the newly cloned project.
